### PR TITLE
Feature/api2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Launch the Junebug service with thet Vumi Messenger channel configured::
         --channels facebook:vxmessenger.transport.MessengerTransport \
         --logging-path .
 
-Using the template, below and update your FB_APP_ID, FB_ACCESS_TOKEN and
+Using the template, below and update your FB_PAGE_ID, FB_ACCESS_TOKEN and
 save it as a file called ``config.json``:
 
 .. code-block:: json
@@ -51,7 +51,7 @@ save it as a file called ``config.json``:
         "web_path": "/api",
         "web_port": 8051,
         "noisy": true,
-        "app_id": "YOUR_FB_PAGE_APP_ID",
+        "page_id": "YOUR_FB_PAGE_ID",
         "retrieve_profile": true,
         "welcome_message": [{
           "message": {

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ save it as a file called ``config.json``:
         "web_path": "/api",
         "web_port": 8051,
         "noisy": true,
-        "app_id": "YOUR_FB_APP_ID",
+        "app_id": "YOUR_FB_PAGE_APP_ID",
         "retrieve_profile": true,
         "welcome_message": [{
           "message": {

--- a/vxmessenger/transport.py
+++ b/vxmessenger/transport.py
@@ -25,6 +25,9 @@ class MessengerTransportConfig(HttpRpcTransport.CONFIG_CLASS):
         "The page id for the Messenger API",
         required=False,
         fallbacks=[SingleFieldFallback("app_id")])
+    app_id = ConfigText(
+        "DEPRECATED The page app id for the Messenger API",
+        required=False)
     welcome_message = ConfigDict(
         ("The payload for setting up a welcome message. "
          "Requires a page_id to be set"),

--- a/vxmessenger/transport.py
+++ b/vxmessenger/transport.py
@@ -139,7 +139,7 @@ class MessengerTransport(HttpRpcTransport):
     def setup_welcome_message(self, welcome_message_payload, app_id):
         response = yield self.request(
             'POST',
-            "https://graph.facebook.com/v2.5/%s/thread_settings?%s" % (
+            "https://graph.facebook.com/v2.6/%s/thread_settings?%s" % (
                 app_id,
                 urlencode({
                     'access_token': self.config['access_token'],
@@ -221,7 +221,7 @@ class MessengerTransport(HttpRpcTransport):
     def get_user_profile(self, user_id):
         response = yield self.request(
             method='GET',
-            url='https://graph.facebook.com/v2.5/%s?%s' % (
+            url='https://graph.facebook.com/v2.6/%s?%s' % (
                 user_id, urlencode({
                     'fields': 'first_name,last_name,profile_pic',
                     'access_token': self.config['access_token'],

--- a/vxmessenger/transport.py
+++ b/vxmessenger/transport.py
@@ -4,6 +4,8 @@ from urllib import urlencode
 
 import treq
 
+
+from confmodel.fallbacks import SingleFieldFallback
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.error import TimeoutError
@@ -19,12 +21,13 @@ class MessengerTransportConfig(HttpRpcTransport.CONFIG_CLASS):
     access_token = ConfigText(
         "The access_token for the Messenger API",
         required=True)
-    app_id = ConfigText(
-        "The app id for the Messenger API",
-        required=False)
+    page_id = ConfigText(
+        "The page id for the Messenger API",
+        required=False,
+        fallbacks=[SingleFieldFallback("app_id")])
     welcome_message = ConfigDict(
         ("The payload for setting up a welcome message. "
-         "Requires an app_id to be set"),
+         "Requires a page_id to be set"),
         required=False)
     retrieve_profile = ConfigBool(
         "Set to true to include the user profile details in "
@@ -117,13 +120,13 @@ class MessengerTransport(HttpRpcTransport):
         yield super(MessengerTransport, self).setup_transport()
         self.pool = HTTPConnectionPool(self.clock, persistent=False)
         if self.config.get('welcome_message'):
-            if not self.config.get('app_id'):
-                self.log.error('app_id is required for welcome_message')
+            if not self.config.get('page_id'):
+                self.log.error('page_id is required for welcome_message')
                 return
             try:
                 data = yield self.setup_welcome_message(
                     self.config['welcome_message'],
-                    self.config['app_id'])
+                    self.config['page_id'])
                 self.log.info('Set welcome message: %s' % (data,))
             except (MessengerTransport,), e:
                 self.log.error('Failed to setup welcome message: %s' % (e,))
@@ -136,11 +139,11 @@ class MessengerTransport(HttpRpcTransport):
                 self.request_gc.stop()
 
     @inlineCallbacks
-    def setup_welcome_message(self, welcome_message_payload, app_id):
+    def setup_welcome_message(self, welcome_message_payload, page_id):
         response = yield self.request(
             'POST',
             "https://graph.facebook.com/v2.6/%s/thread_settings?%s" % (
-                app_id,
+                page_id,
                 urlencode({
                     'access_token': self.config['access_token'],
                 })),


### PR DESCRIPTION
2 Changes:
Using FB API 2.6, since it is now stable
Update README to note that the FB Page-app-id should be used.