### PR TITLE
Buttons now support optional type 'web_url'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ limits appy.
             'messenger': {
                 'template_type': 'button'
                 'text': 'The accompanying text with the button',
-                'buttons': [{
+                'buttons': [{ # Up to 3 buttons
                     'type': 'postback', # defaults to postback if not specified
                     'title': 'Button 1',
                     'payload': {
@@ -155,7 +155,7 @@ A Generic Reply
 ~~~~~~~~~~~~~~
 
 Please be aware of the limitations_ that Facebook applies to these messages.
-A call to action may only have a maximum of 3 buttons and character count
+A call to action may only have a maximum of 3 buttons, 10 elements, and character count
 limits appy.
 
 .. code-block:: python
@@ -164,11 +164,11 @@ limits appy.
         helper_metadata={
             'messenger': {
                 'template_type': 'generic'
-                'elements': [
+                'elements': [{ # Up to 10 elements
                     'title': 'The title',
                     'subtitle': 'The subtitle', # This can be left blank
                     'image_url': 'The image_url to use', # This can be left blank
-                    'buttons': [{
+                    'buttons': [{ # Up to 3 buttons
                         'type': 'postback', # defaults to postback if not specified
                         'title': 'Button 1',
                         'payload': {
@@ -180,7 +180,7 @@ limits appy.
                         'title': 'Button 2',
                         'url': 'http://some.url'
                     }]
-                ]
+                }]
             }
         })
 

--- a/README.rst
+++ b/README.rst
@@ -137,11 +137,16 @@ limits appy.
                 'template_type': 'button'
                 'text': 'The accompanying text with the button',
                 'buttons': [{
+                    'type': 'postback', # defaults to postback if not specified
                     'title': 'Button 1',
                     'payload': {
                         'content': 'The content expected when a button is pressed',
                         'in_reply_to': 'The ID of the previous message' # This can be left blank
                     }
+                }, {
+                    'type': 'web_url',
+                    'title': 'Button 2',
+                    'url': 'http://some.url'
                 }]
             }
         })
@@ -161,14 +166,19 @@ limits appy.
                 'template_type': 'generic'
                 'elements': [
                     'title': 'The title',
-                    'subtitle': 'The subtitle',
+                    'subtitle': 'The subtitle', # This can be left blank
                     'image_url': 'The image_url to use', # This can be left blank
                     'buttons': [{
+                        'type': 'postback', # defaults to postback if not specified
                         'title': 'Button 1',
                         'payload': {
                             'content': 'The content expected when a button is pressed',
                             'in_reply_to': 'The ID of the previous message' # This can be left blank
                         }
+                    }, {
+                        'type': 'web_url',
+                        'title': 'Button 2',
+                        'url': 'http://some.url'
                     }]
                 ]
             }

--- a/vxmessenger/transport.py
+++ b/vxmessenger/transport.py
@@ -50,7 +50,7 @@ class Page(object):
         self.timestamp = timestamp
 
     def __str__(self):
-        ("<Page to_addr: %s, from_addr: %s, in_reply_to: %s, content: %s, "
+        return ("<Page to_addr: %s, from_addr: %s, in_reply_to: %s, content: %s, "
          "mid: %s, timestamp: %s>") % (self.to_addr,
                                        self.from_addr,
                                        self.in_reply_to,
@@ -252,6 +252,20 @@ class MessengerTransport(HttpRpcTransport):
 
         return self.construct_plain_reply(message)
 
+    def construct_button(self, btn):
+        typ = btn.get('type', 'postback')
+        ret = {
+            'type': typ,
+            'title': btn['title'],
+        }
+        if typ == 'postback':
+            ret['payload'] = json.dumps(btn['payload'], separators=(',', ':'))
+        elif typ == 'web_url':
+            ret['url'] = btn['url']
+        else:
+            raise UnsupportedMessage('Unknown button type "%s"' % typ)
+        return ret
+
     def construct_button_reply(self, message):
         button = message['helper_metadata']['messenger']
         return {
@@ -264,13 +278,8 @@ class MessengerTransport(HttpRpcTransport):
                     'payload': {
                         'template_type': 'button',
                         'text': button['text'],
-                        'buttons': [
-                            {
-                                'type': 'postback',
-                                'title': btn['title'],
-                                'payload': json.dumps(btn['payload']),
-                            } for btn in button['buttons']
-                        ]
+                        'buttons': [self.construct_button(btn)
+                                    for btn in button['buttons']]
                     }
                 }
             }
@@ -289,15 +298,10 @@ class MessengerTransport(HttpRpcTransport):
                         'template_type': 'generic',
                         'elements': [{
                             'title': element['title'],
-                            'subtitle': element['subtitle'],
+                            'subtitle': element.get('subtitle'),
                             'image_url': element.get('image_url'),
-                            'buttons': [
-                                {
-                                    'type': 'postback',
-                                    'title': btn['title'],
-                                    'payload': json.dumps(btn['payload']),
-                                } for btn in element['buttons']
-                            ]
+                            'buttons': [self.construct_button(btn)
+                                        for btn in element['buttons']]
                         } for element in button['elements']]
                     }
                 }

--- a/vxmessenger/transport.py
+++ b/vxmessenger/transport.py
@@ -50,13 +50,14 @@ class Page(object):
         self.timestamp = timestamp
 
     def __str__(self):
-        return ("<Page to_addr: %s, from_addr: %s, in_reply_to: %s, content: %s, "
-         "mid: %s, timestamp: %s>") % (self.to_addr,
-                                       self.from_addr,
-                                       self.in_reply_to,
-                                       self.content,
-                                       self.mid,
-                                       self.timestamp)
+        return ("<Page to_addr: %s, from_addr: %s, in_reply_to: %s, "
+                "content: %s, mid: %s, timestamp: %s>") % (
+            self.to_addr,
+            self.from_addr,
+            self.in_reply_to,
+            self.content,
+            self.mid,
+            self.timestamp)
 
     @classmethod
     def from_fp(cls, fp):


### PR DESCRIPTION
Added support for 'web_url' in button and generic replies.
Updated tests, and added a test for failiure.

I also added a parameter to squish the `payload` value, as it is also length-limited according to the FB docs.