### PR TITLE
Feature/unpinning

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,17 @@
+# Required packages pinned
+Klein==15.3.1
+click==6.4
+treq==15.1.0
+vumi==0.6.3
+junebug==0.1.3
+
+# Optional packages pinned
+Django==1.9.5
+psycopg2==2.6.1
+raven<=5.0.0
+dj-database-url==0.4.0
+
+# Dev/testing packages
 flake8==2.4.1
 coverage==4.0
 Sphinx==1.3.1
@@ -5,3 +19,4 @@ pytest==2.8.2
 pytest-xdist==1.13.1
 pytest-cov==2.2.0
 pytest-django==2.9.1
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,22 +1,22 @@
 # Required packages pinned
 Klein==15.3.1
-click==6.4
+click==6.6
 treq==15.1.0
-vumi==0.6.3
-junebug==0.1.3
+vumi==0.6.7
+junebug==0.1.5
 
 # Optional packages pinned
 Django==1.9.5
 psycopg2==2.6.1
 raven<=5.0.0
-dj-database-url==0.4.0
+dj-database-url==0.4.1
 
 # Dev/testing packages
-flake8==2.4.1
-coverage==4.0
-Sphinx==1.3.1
-pytest==2.8.2
-pytest-xdist==1.13.1
-pytest-cov==2.2.0
+flake8==2.5.4
+coverage==4.0.3
+Sphinx==1.4.1
+pytest==2.9.1
+pytest-xdist==1.14
+pytest-cov==2.2.1
 pytest-django==2.9.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-Klein==15.3.1
-click==6.4
-treq==15.1.0
-Django==1.9.5
-psycopg2==2.6.1
-raven<=5.0.0
-dj-database-url==0.4.0
-vumi==0.6.3
-junebug==0.1.3
+Klein
+click
+treq
+vumi
+junebug


### PR DESCRIPTION
Minimised what is in requirements.txt to required modules, not optional. (The django portion isn't always used)
Moved all locking to requirements-dev.txt so that dev/testing can still be locked to known modules.
Updated all pinned packages to latest, except raven which was specified as <=5.