### PR TITLE
Extra data/flows support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ If you've used a different ``web_port`` and ``web_path`` parameter you'll need t
     ``/jb/`` endpoint, all other transports are made available from the root path.
     For the example above the endpoint would be ``/api`` on port 80.
 
+
 Hook up an Application to your Messenger integration
 ====================================================
 
@@ -140,8 +141,12 @@ limits appy.
                     'type': 'postback', # defaults to postback if not specified
                     'title': 'Button 1',
                     'payload': {
-                        'content': 'The content expected when a button is pressed',
-                        'in_reply_to': 'The ID of the previous message' # This can be left blank
+                        # In here you can put whatever you want to
+                        # 'content' and 'in_reply_to' will go into the standard vumi message
+                        'content': 'The content expected when a button is pressed', # This can be left blank
+                        'in_reply_to': 'The ID of the previous message', # This can be left blank
+                        # Anything else will end up in transport_metadata.messenger
+                        'anything_extra': 'Bonus!'
                     }
                 }, {
                     'type': 'web_url',
@@ -172,8 +177,12 @@ limits appy.
                         'type': 'postback', # defaults to postback if not specified
                         'title': 'Button 1',
                         'payload': {
-                            'content': 'The content expected when a button is pressed',
-                            'in_reply_to': 'The ID of the previous message' # This can be left blank
+                            # In here you can put whatever you want to
+                            # 'content' and 'in_reply_to' will go into the standard vumi message
+                            'content': 'The content expected when a button is pressed', # This can be left blank
+                            'in_reply_to': 'The ID of the previous message', # This can be left blank
+                            # Anything else will end up in transport_metadata.messenger
+                            'anything_extra': 'Bonus!'
                         }
                     }, {
                         'type': 'web_url',
@@ -183,6 +192,66 @@ limits appy.
                 }]
             }
         })
+
+
+Message format
+==============
+
+Due to some extra features of the messenger platform, there is some extra data that you may need to pay attention to:
+
+**transport_metadata:**
+
+Contains a dict ``messenger`` with the following keys:
+
+``mid``:
+    Messenger message id.
+    
+ ``attachments``:
+    List containing dictionaries as such:
+    
+    .. code-block:: json
+    
+        {
+            "type":"image",
+            "payload": {
+                "url":"IMAGE_URL"
+            }
+        }
+
+``optin``:
+    Dict containing a ``ref`` key, which is the PASS_THROUGH_PARAM as defined by:
+
+    https://developers.facebook.com/docs/messenger-platform/plugin-reference#send_to_messenger
+ 
+Other items defined in ``payload``:
+    e.g. ``"anything_extra": "Bonus"``
+
+**helper_metadata:**
+
+Contains a dict ``messenger`` with the user profile as such:
+
+Note: only if ``retrieve_profile`` is configured as ``true``
+
+.. code-block:: json
+    
+    {
+        "first_name": "Firstname",
+        "last_name": "Lastname",
+        "profile_pic": "IMAGE_URL"
+    }
+
+Supported webhooks
+~~~~~~~~~~~~~~~~~~
+
+``messages``:
+    Standard conversational messages & attachments.
+    
+``messaging_postbacks``:
+    Postback buttons.
+
+``messaging_optins``:
+    Send-to-Messenger / authentication callback.
+
 
 .. _Junebug: http://junebug.readthedocs.org
 .. _limitations: https://developers.facebook.com/docs/messenger-platform/send-api-reference#guidelines

--- a/vxmessenger/tests/test_transport.py
+++ b/vxmessenger/tests/test_transport.py
@@ -270,10 +270,10 @@ class TestMessengerTransport(VumiTestCase):
                         "message": {
                             "mid": "mid.1457764197618:41d102a3e1ae206a37",
                             "seq": 63,
-                            "attachments":[{
-                                "type":"image",
+                            "attachments": [{
+                                "type": "image",
                                 "payload": {
-                                    "url":"IMAGE_URL"
+                                    "url": "IMAGE_URL"
                                 }
                             }]
                         }
@@ -293,10 +293,10 @@ class TestMessengerTransport(VumiTestCase):
         self.assertEqual(msg['transport_metadata'], {
             'messenger': {
                 'mid': "mid.1457764197618:41d102a3e1ae206a37",
-                "attachments":[{
-                    "type":"image",
+                "attachments": [{
+                    "type": "image",
                     "payload": {
-                        "url":"IMAGE_URL"
+                        "url": "IMAGE_URL"
                     }
                 }]
             }

--- a/vxmessenger/tests/test_transport.py
+++ b/vxmessenger/tests/test_transport.py
@@ -249,6 +249,104 @@ class TestMessengerTransport(VumiTestCase):
         self.assertEqual(inbound_status['message'], 'Request successful')
 
     @inlineCallbacks
+    def test_inbound_attachments(self):
+        yield self.mk_transport()
+
+        res = yield self.tx_helper.mk_request_raw(
+            method='POST',
+            data=json.dumps({
+                "object": "page",
+                "entry": [{
+                    "id": "PAGE_ID",
+                    "time": 1457764198246,
+                    "messaging": [{
+                        "sender": {
+                            "id": "USER_ID"
+                        },
+                        "recipient": {
+                            "id": "PAGE_ID"
+                        },
+                        "timestamp": 1457764197627,
+                        "message": {
+                            "mid": "mid.1457764197618:41d102a3e1ae206a37",
+                            "seq": 63,
+                            "attachments":[{
+                                "type":"image",
+                                "payload": {
+                                    "url":"IMAGE_URL"
+                                }
+                            }]
+                        }
+                    }]
+                }]
+            }))
+
+        self.assertEqual(res.code, http.OK)
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+
+        self.assertEqual(msg['from_addr'], 'USER_ID')
+        self.assertEqual(msg['to_addr'], 'PAGE_ID')
+        self.assertEqual(msg['from_addr_type'], 'facebook_messenger')
+        self.assertEqual(msg['provider'], 'facebook')
+        self.assertEqual(msg['content'], '')
+        self.assertEqual(msg['transport_metadata'], {
+            'messenger': {
+                'mid': "mid.1457764197618:41d102a3e1ae206a37",
+                "attachments":[{
+                    "type":"image",
+                    "payload": {
+                        "url":"IMAGE_URL"
+                    }
+                }]
+            }
+        })
+
+    @inlineCallbacks
+    def test_inbound_optin(self):
+        yield self.mk_transport()
+
+        res = yield self.tx_helper.mk_request_raw(
+            method='POST',
+            data=json.dumps({
+                "object": "page",
+                "entry": [{
+                    "id": "PAGE_ID",
+                    "time": 1457764198246,
+                    "messaging": [{
+                        "sender": {
+                            "id": "USER_ID"
+                        },
+                        "recipient": {
+                            "id": "PAGE_ID"
+                        },
+                        "timestamp": 1457764197627,
+                        "optin": {
+                            "ref": "PASS_THROUGH_PARAM"
+                        }
+                    }]
+                }]
+            }))
+
+        self.assertEqual(res.code, http.OK)
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+
+        self.assertEqual(msg['from_addr'], 'USER_ID')
+        self.assertEqual(msg['to_addr'], 'PAGE_ID')
+        self.assertEqual(msg['from_addr_type'], 'facebook_messenger')
+        self.assertEqual(msg['provider'], 'facebook')
+        self.assertEqual(msg['content'], '')
+        self.assertEqual(msg['transport_metadata'], {
+            'messenger': {
+                'mid': None,
+                "optin": {
+                    "ref": "PASS_THROUGH_PARAM"
+                }
+            }
+        })
+
+    @inlineCallbacks
     def test_inbound_postback(self):
         yield self.mk_transport()
 
@@ -281,8 +379,62 @@ class TestMessengerTransport(VumiTestCase):
 
         [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
 
+        self.assertEqual(msg['from_addr'], 'USER_ID')
+        self.assertEqual(msg['to_addr'], 'PAGE_ID')
+        self.assertEqual(msg['from_addr_type'], 'facebook_messenger')
+        self.assertEqual(msg['provider'], 'facebook')
         self.assertEqual(msg['content'], '1')
         self.assertEqual(msg['in_reply_to'], '12345')
+        self.assertEqual(msg['transport_metadata'], {
+            'messenger': {
+                'mid': None
+            }
+        })
+
+    @inlineCallbacks
+    def test_inbound_postback_other(self):
+        yield self.mk_transport()
+
+        res = yield self.tx_helper.mk_request_raw(
+            method='POST',
+            data=json.dumps({
+                "object": "page",
+                "entry": [{
+                    "id": "PAGE_ID",
+                    "time": 1457764198246,
+                    "messaging": [{
+                        "sender": {
+                            "id": "USER_ID"
+                        },
+                        "recipient": {
+                            "id": "PAGE_ID"
+                        },
+                        "timestamp": 1457764197627,
+                        "postback": {
+                            "payload": json.dumps({
+                                "postback": "ocean"
+                            })
+                        }
+                    }]
+                }]
+            }))
+
+        self.assertEqual(res.code, http.OK)
+
+        [msg] = yield self.tx_helper.wait_for_dispatched_inbound(1)
+
+        self.assertEqual(msg['from_addr'], 'USER_ID')
+        self.assertEqual(msg['to_addr'], 'PAGE_ID')
+        self.assertEqual(msg['from_addr_type'], 'facebook_messenger')
+        self.assertEqual(msg['provider'], 'facebook')
+        self.assertEqual(msg['content'], '')
+        self.assertEqual(msg['in_reply_to'], None)
+        self.assertEqual(msg['transport_metadata'], {
+            'messenger': {
+                'mid': None,
+                "postback": "ocean"
+            }
+        })
 
     @inlineCallbacks
     def test_inbound_with_user_profile(self):


### PR DESCRIPTION
With this pull request I think vumi-messenger should be about as feature complete as needed.

* Handles attachments and optin message types.
* Allows arbritraty `postback` parameters.
* Will not fail with 502/504 when no messages received are handled, this prevents messenger re-transmitting the unhandled message repeatedly until it blacklists you. In essence a hard-breakage.
* Added some tests
* Updated documentation